### PR TITLE
Avoid wrong overload when creating tensor from 1D array

### DIFF
--- a/src/tensor_addons.hpp
+++ b/src/tensor_addons.hpp
@@ -24,6 +24,34 @@
 
 template <typename type_, typename... options>
 void tensor_addons(pybind11::class_<type_, options...> &cl) {
+    cl.def("__init__", [](Tensor &t, pybind11::buffer b, int device) {
+        pybind11::buffer_info info = b.request();
+        if (info.format != pybind11::format_descriptor<float>::format())
+            throw std::runtime_error("Invalid format: expected a float array");
+        bool have_simple_strides = true;
+        std::vector<ssize_t> simple_strides(info.ndim);
+        ssize_t S = sizeof(float);
+        for (int i = info.ndim - 1; i >=0; --i) {
+            simple_strides[i] = S;
+            S *= info.shape[i];
+        }
+        for (int i = 0; i < info.ndim; ++i) {
+            if (info.strides[i] != simple_strides[i]) {
+                have_simple_strides = false;
+                break;
+            }
+        }
+        std::vector<int> shape(info.ndim);
+        for (int i = 0; i < info.ndim; ++i) {
+            shape[i] = info.shape[i];
+        }
+        new(&t) Tensor(shape, device);
+        if (have_simple_strides) {
+            std::copy((float*)info.ptr, ((float*)info.ptr) + t.size, t.ptr);
+        } else {
+            throw std::runtime_error("complex strides not supported");
+        }
+	}, pybind11::arg("buf"), pybind11::arg("dev") = DEV_CPU);
     cl.def(pybind11::init<const vector<int>&, int>(),
            pybind11::arg("shape"), pybind11::arg("dev") = DEV_CPU,
            pybind11::keep_alive<1, 2>());
@@ -73,32 +101,4 @@ void tensor_addons(pybind11::class_<type_, options...> &cl) {
               strides
         );
     });
-    cl.def("__init__", [](Tensor &t, pybind11::buffer b, int device) {
-        pybind11::buffer_info info = b.request();
-        if (info.format != pybind11::format_descriptor<float>::format())
-            throw std::runtime_error("Invalid format: expected a float array");
-        bool have_simple_strides = true;
-        std::vector<ssize_t> simple_strides(info.ndim);
-        ssize_t S = sizeof(float);
-        for (int i = info.ndim - 1; i >=0; --i) {
-            simple_strides[i] = S;
-            S *= info.shape[i];
-        }
-        for (int i = 0; i < info.ndim; ++i) {
-            if (info.strides[i] != simple_strides[i]) {
-                have_simple_strides = false;
-                break;
-            }
-        }
-        std::vector<int> shape(info.ndim);
-        for (int i = 0; i < info.ndim; ++i) {
-            shape[i] = info.shape[i];
-        }
-        new(&t) Tensor(shape, device);
-        if (have_simple_strides) {
-            std::copy((float*)info.ptr, ((float*)info.ptr) + t.size, t.ptr);
-        } else {
-            throw std::runtime_error("complex strides not supported");
-        }
-	}, pybind11::arg("buf"), pybind11::arg("dev") = DEV_CPU);
 }

--- a/tests/test_eddlT.py
+++ b/tests/test_eddlT.py
@@ -39,6 +39,11 @@ def test_create_getdata():
     a = np.arange(R * C).reshape(R, C)
     t = eddlT.create(a)
     assert t.shape == [R, C]
+    # check creation from 1D array
+    a = np.array([1, 2]).astype(np.float32)
+    t = eddlT.create(a)
+    b = eddlT.getdata(t)
+    assert np.array_equal(b, a)
 
 
 def test_ones():

--- a/tests/test_tensor.py
+++ b/tests/test_tensor.py
@@ -40,6 +40,11 @@ def test_tensor_from_array():
     assert t.isCPU()
     b = np.array(t, copy=True)
     assert np.array_equal(a, b)
+    # check creation from 1D array
+    a = np.array([1, 2]).astype(np.float32)
+    t = Tensor(a)
+    b = np.array(t, copy=True)
+    assert np.array_equal(a, b)
 
 
 def test_tensor_array_ops():


### PR DESCRIPTION
Fixes #10.

Applies the workaround described in https://github.com/pybind/pybind11/issues/2027. Unfortunately it only works if the array is of type `np.float32`.