### PR TITLE
Fix tensor from array creation

### DIFF
--- a/src/tensor_addons.hpp
+++ b/src/tensor_addons.hpp
@@ -21,38 +21,19 @@
 #pragma once
 
 #include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
 
 template <typename type_, typename... options>
 void tensor_addons(pybind11::class_<type_, options...> &cl) {
-    cl.def(pybind11::init([](pybind11::buffer b, int device) {
-        pybind11::buffer_info info = b.request();
-        if (info.format != pybind11::format_descriptor<float>::format())
-            throw std::runtime_error("Invalid format: expected a float array");
-        bool have_simple_strides = true;
-        std::vector<ssize_t> simple_strides(info.ndim);
-        ssize_t S = sizeof(float);
-        for (int i = info.ndim - 1; i >=0; --i) {
-            simple_strides[i] = S;
-            S *= info.shape[i];
-        }
-        for (int i = 0; i < info.ndim; ++i) {
-            if (info.strides[i] != simple_strides[i]) {
-                have_simple_strides = false;
-                break;
-            }
-        }
-        std::vector<int> shape(info.ndim);
-        for (int i = 0; i < info.ndim; ++i) {
-            shape[i] = info.shape[i];
-        }
+    using array_t = pybind11::array_t<float, pybind11::array::c_style | pybind11::array::forcecast>;
+    cl.def(pybind11::init([](array_t array, int device) {
+        pybind11::buffer_info info = array.request();
+        std::vector<int> shape(info.shape.begin(), info.shape.end());
         auto t = new Tensor(shape, device);
-        if (have_simple_strides) {
-            std::copy((float*)info.ptr, ((float*)info.ptr) + t->size, t->ptr);
-        } else {
-            throw std::runtime_error("complex strides not supported");
-        }
-	return t;
-	}), pybind11::arg("buf"), pybind11::arg("dev") = DEV_CPU);
+        std::copy((float*)info.ptr, ((float*)info.ptr) + t->size, t->ptr);
+        return t;
+    }), pybind11::arg("buf"), pybind11::arg("dev") = DEV_CPU);
     cl.def(pybind11::init<const vector<int>&, int>(),
            pybind11::arg("shape"), pybind11::arg("dev") = DEV_CPU,
            pybind11::keep_alive<1, 2>());


### PR DESCRIPTION
Multiple fixes for the `Tensor` constructor from array:

* replace [deprecated placement new constructor](https://pybind11.readthedocs.io/en/stable/upgrade.html#new-api-for-defining-custom-constructors-and-pickling-functions) with new approach
* explicitly allow construction from array (not just a generic buffer)
* allow GPU tensor creation (if EDDL was not compiled for GPU, creates a CPU tensor even if `DEV_GPU` is passed as device)