### PR TITLE
Fix getout forward

### DIFF
--- a/examples/onnx/check_getout_forward.py
+++ b/examples/onnx/check_getout_forward.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2020 CRS4
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""\
+Check usage of getOut and forward in a network with a non-empty lout.
+"""
+
+import argparse
+import os
+import sys
+
+import pyeddl.eddl as eddl
+from pyeddl.tensor import Tensor
+
+
+def main(args):
+    if not os.path.isfile(args.input):
+        raise RuntimeError("input file '%s' not found" % args.input)
+
+    eddl.download_mnist()
+
+    net = eddl.import_net_from_onnx_file(args.input)
+    eddl.build(
+        net,
+        eddl.rmsprop(0.01),
+        ["soft_cross_entropy"],
+        ["categorical_accuracy"],
+        eddl.CS_GPU([1]) if args.gpu else eddl.CS_CPU(),
+        False  # do not initialize weights to random values
+    )
+
+    net.resize(args.batch_size)  # resize manually since we don't use "fit"
+    eddl.summary(net)
+
+    x_test = Tensor.load("mnist_tsX.bin")
+    x_test.div_(255.0)
+
+    sys.stderr.write("forward...\n")
+    eddl.forward(net, [x_test])
+    sys.stderr.write("forward done\n")
+
+    sys.stderr.write("lout: %r\n" % (net.lout,))
+    out = eddl.getOut(net)
+    sys.stderr.write("getOut done\n")
+    sys.stderr.write("out: %r\n" % (out,))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--batch-size", type=int, metavar="INT", default=1000)
+    parser.add_argument("--gpu", action="store_true")
+    parser.add_argument("--input", metavar="STRING",
+                        default="trained_model.onnx",
+                        help="input path of the serialized model")
+    main(parser.parse_args(sys.argv[1:]))

--- a/examples/onnx/run_all_fast.sh
+++ b/examples/onnx/run_all_fast.sh
@@ -14,8 +14,11 @@ names=(
 
 for n in "${names[@]}"; do
     echo -en "\n*** ${n} ***\n"
-    python3 "${this_dir}"/${n}.py --gpu --epochs 1
+    python3 "${this_dir}"/${n}.py --gpu --epochs 1 --small
 done
 
 echo -en "\n*** import_net_from_file ***\n"
 python3 "${this_dir}"/import_net_from_file.py --gpu
+
+echo -en "\n*** check_getout_forward ***\n"
+python3 "${this_dir}"/check_getout_forward.py --gpu

--- a/examples/onnx/save_net_to_file.py
+++ b/examples/onnx/save_net_to_file.py
@@ -62,6 +62,11 @@ def main(args):
     y_train = Tensor.load("mnist_trY.bin")
     x_test = Tensor.load("mnist_tsX.bin")
     y_test = Tensor.load("mnist_tsY.bin")
+    if args.small:
+        x_train = x_train.select([":6000"])
+        y_train = y_train.select([":6000"])
+        x_test = x_test.select([":1000"])
+        y_test = y_test.select([":1000"])
 
     x_train.div_(255.0)
     x_test.div_(255.0)
@@ -81,4 +86,5 @@ if __name__ == "__main__":
     parser.add_argument("--output", metavar="STRING",
                         default="trained_model.onnx",
                         help="output path for the serialized model")
+    parser.add_argument("--small", action="store_true")
     main(parser.parse_args(sys.argv[1:]))

--- a/examples/onnx/to_from_string.py
+++ b/examples/onnx/to_from_string.py
@@ -60,6 +60,11 @@ def main(args):
     y_train = Tensor.load("mnist_trY.bin")
     x_test = Tensor.load("mnist_tsX.bin")
     y_test = Tensor.load("mnist_tsY.bin")
+    if args.small:
+        x_train = x_train.select([":6000"])
+        y_train = y_train.select([":6000"])
+        x_test = x_test.select([":1000"])
+        y_test = y_test.select([":1000"])
 
     x_train.div_(255.0)
     x_test.div_(255.0)
@@ -92,4 +97,5 @@ if __name__ == "__main__":
     parser.add_argument("--epochs", type=int, metavar="INT", default=1)
     parser.add_argument("--batch-size", type=int, metavar="INT", default=100)
     parser.add_argument("--gpu", action="store_true")
+    parser.add_argument("--small", action="store_true")
     main(parser.parse_args(sys.argv[1:]))

--- a/src/eddl_addons.hpp
+++ b/src/eddl_addons.hpp
@@ -193,15 +193,15 @@ void eddl_addons(pybind11::module &m) {
     m.def("eval_batch", (void (*)(class Net*, vector<Tensor*>, vector<Tensor*>, vector<int>)) &eddl::eval_batch, "C++: eddl::eval_batch(class Net*, vector<Tensor*>, vector<Tensor*>, vector<int>) --> void", pybind11::call_guard<pybind11::gil_scoped_release>(), pybind11::arg("net"), pybind11::arg("in"), pybind11::arg("out"), pybind11::arg("indices"));
     m.def("eval_batch", (void (*)(class Net*, vector<Tensor*>, vector<Tensor*>)) &eddl::eval_batch, "C++: eddl::eval_batch(class Net*, vector<Tensor*>, vector<Tensor*>) --> void", pybind11::call_guard<pybind11::gil_scoped_release>(), pybind11::arg("net"), pybind11::arg("in"), pybind11::arg("out"));
     m.def("next_batch", (void (*)(vector<Tensor*>, vector<Tensor*>)) &eddl::next_batch, "C++: eddl::next_batch(vector<Tensor*>, vector<Tensor*>) --> void", pybind11::arg("in"), pybind11::arg("out"));
-    m.def("forward", (vector<Layer*> (*)(class Net*, vector<Layer*>)) &eddl::forward, "C++: eddl::forward(class Net*, vector<Layer*>) --> vector<Layer*>", pybind11::arg("m"), pybind11::arg("in"));
-    m.def("forward", (vector<Layer*> (*)(class Net*, vector<Tensor*>)) &eddl::forward, "C++: eddl::forward(class Net*, vector<Tensor*>) --> vector<Layer*>", pybind11::arg("m"), pybind11::arg("in"));
-    m.def("forward", (vector<Layer*> (*)(class Net*)) &eddl::forward, "C++: eddl::forward(class Net*) --> vector<Layer*>", pybind11::arg("m"));
-    m.def("forward", (vector<Layer*> (*)(class Net*, int)) &eddl::forward, "C++: eddl::forward(class Net*, int) --> vector<Layer*>", pybind11::arg("m"), pybind11::arg("b"));
+    m.def("forward", (vector<Layer*> (*)(class Net*, vector<Layer*>)) &eddl::forward, "C++: eddl::forward(class Net*, vector<Layer*>) --> vector<Layer*>", pybind11::return_value_policy::reference, pybind11::arg("m"), pybind11::arg("in"));
+    m.def("forward", (vector<Layer*> (*)(class Net*, vector<Tensor*>)) &eddl::forward, "C++: eddl::forward(class Net*, vector<Tensor*>) --> vector<Layer*>", pybind11::return_value_policy::reference, pybind11::arg("m"), pybind11::arg("in"));
+    m.def("forward", (vector<Layer*> (*)(class Net*)) &eddl::forward, "C++: eddl::forward(class Net*) --> vector<Layer*>", pybind11::return_value_policy::reference, pybind11::arg("m"));
+    m.def("forward", (vector<Layer*> (*)(class Net*, int)) &eddl::forward, "C++: eddl::forward(class Net*, int) --> vector<Layer*>", pybind11::return_value_policy::reference, pybind11::arg("m"), pybind11::arg("b"));
     m.def("detach", (class Layer* (*)(class Layer*)) &eddl::detach, "C++: eddl::detach(class Layer*) --> class Layer*", pybind11::return_value_policy::reference, pybind11::arg("l"));
     m.def("detach", (class vector<Layer*> (*)(class vector<Layer*>)) &eddl::detach, "C++: eddl::detach(class vector<Layer*>) --> class vector<Layer*>", pybind11::return_value_policy::reference, pybind11::arg("l"));
     m.def("backward", (void (*)(class Net*, vector<Tensor*>)) &eddl::backward, "C++: eddl::backward(class Net*, vector<Tensor*>) --> void", pybind11::arg("m"), pybind11::arg("target"));
     m.def("optimize", (void (*)(vector<NetLoss*>)) &eddl::optimize, "C++: eddl::optimize(vector<NetLoss*>) --> void", pybind11::arg("l"));
-    m.def("getOut", (vector<Layer*> (*)(class Net*)) &eddl::getOut, "C++: eddl::getOut(class Net*) --> vector<Layer*>", pybind11::arg("net"));
+    m.def("getOut", (vector<Layer*> (*)(class Net*)) &eddl::getOut, "C++: eddl::getOut(class Net*) --> vector<Layer*>", pybind11::return_value_policy::reference, pybind11::arg("net"));
 
     // --- manage tensors inside layers ---
     m.def("getParams", (vector<Tensor*> (*)(class Layer *)) &eddl::getParams, "C++: eddl::getParams(class Layer *) --> vector<Tensor*>", pybind11::arg("l1"));


### PR DESCRIPTION
Fixes #41.

When [eddl::getOut](https://github.com/deephealthproject/eddl/blob/0.6.0/src/apis/eddl.cpp#L939) returns `net->lout` directly, the caller has a reference to an object that's already being deleted by the `Net` destructor. So the segfault reported in #41 also happens in C++ if one deletes both the net object and the vector of layers returned by getOut. In Python this always happens automatically when the interpreter exits, so here we change the `getOut` return value policy to avoid the deletion of the returned vector of layers.

`forward` is also affected, since its implementation(s) uses `getOut` (again, see [eddl.cpp](https://github.com/deephealthproject/eddl/blob/0.6.0/src/apis/eddl.cpp)).
